### PR TITLE
Add a network page as the first element in a "reference" section.

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -85,6 +85,27 @@ const config: Config = {
       ]
     },
     {
+      label: 'Network',
+      content: [
+        {
+          label: 'Faucet',
+          path: 'https://faucet.testnet-1.topos.technology/'
+        },
+        {
+          label: 'Blockscout',
+          path: 'https://topos.blockscout.testnet-1.topos.technology/'
+        },
+        {
+          label: 'Explorer',
+          path: 'https://explorer.testnet-1.topos.technology/'
+        },
+        {
+          label: 'Important Addresses',
+          path: '/content/topos-reference/network.html'
+        }
+      ]
+    },
+    {
       label: 'Topos Terms',
       content: [
         {

--- a/content/topos-reference/network.md
+++ b/content/topos-reference/network.md
@@ -1,0 +1,23 @@
+---
+title: Topos Network Reference
+description: Important Network Addresses for Topos
+---
+
+# Important Network Addresses for the Topos Testnet
+
+## Faucet
+
+The Topos Faucet for the Testnet can be found at [https://faucet.testnet-1.topos.technology/](https://faucet.testnet-1.topos.technology/).
+
+## Blockscout
+
+The Topos Blockscout can be found at [https://topos.blockscout.testnet-1.topos.technology/](https://topos.blockscout.testnet-1.topos.technology/).
+
+## Explorer
+
+The Topos network explorer can be found at [https://explorer.testnet-1.topos.technology/](https://explorer.testnet-1.topos.technology/).
+
+## Important Contract Addresses
+
+* ToposCoreProxy: 0x5a9957D674622F4562A0673D14105e36509F381d
+* SubnetRegistrator: 0xA14bF3186C276B0991f21135507aD6A26161F856


### PR DESCRIPTION
# Description

We need to add a "Network" page to the docs portal, with important addresses. 

## Additions and Changes

It did not feel like this page fit well under the existing categories of pages, so a new category was created. This will likely shift further as more pages are added (FAQ, future deeply technical details, actual guides and tutorials), but this should suffice for now to get this information in a readily discoverable location.

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
