### PR TITLE
fix: remove deprecated contract addresses

### DIFF
--- a/content/topos-reference/network.md
+++ b/content/topos-reference/network.md
@@ -18,8 +18,3 @@ The Incal Blockscout can be found at [https://incal.blockscout.testnet-1.topos.t
 ## Explorer
 
 The Topos network explorer can be found at [https://explorer.testnet-1.topos.technology/](https://explorer.testnet-1.topos.technology/).
-
-## Important Contract Addresses
-
-* ToposCoreProxy: 0x5a9957D674622F4562A0673D14105e36509F381d
-* SubnetRegistrator: 0xA14bF3186C276B0991f21135507aD6A26161F856


### PR DESCRIPTION
# Description

This PR removes deprecated contract addresses from the `Important Addresses` page. These addresses have changed since the initial documented ones, and are prone to change. Until a complete solution for advertising the right addresses has been found (the discussion coincidentally started today), we prevent from risking advertising deprecated addresses.

@wyhaines I'm not even sure we should keep this page as all the linked apps are already linked right before in the portal page order. What do you think?

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
