### PR TITLE
There was an extra underscore character in the URL.

### DIFF
--- a/content/module-2/4-topos-zkevm-demo.md
+++ b/content/module-2/4-topos-zkevm-demo.md
@@ -16,7 +16,7 @@ In addition to the Topos Playground, there is another tool for interacting with 
 #### Software
 
 - Linux or MacOS
-- [Docker](https://docs.docker.com/get-docker/_) version 17.06.0 or greater
+- [Docker](https://docs.docker.com/get-docker/) version 17.06.0 or greater
 - [Docker Compose](https://docs.docker.com/compose/install/) version 2.0.0 or greater
 - [NodeJS](https://nodejs.dev/en/) version 16.0.0 or greater
 - [Rust](https://www.rust-lang.org/tools/install) recent nightly (2024)


### PR DESCRIPTION
# Description

The link to the get_docker page for installing Docker has an extra underscore and is thus broken. This fixes it.

## PR Checklist:

- [ x ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
