### PR TITLE
Add a docs site build version indicator in the footer.

### DIFF
--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -1,7 +1,9 @@
 import createPages from './src/gatsby/createPages';
 import onCreateNode from './src/gatsby/onCreateNode';
+import onPreBuild from './src/gatsby/onPreBuild';
 
 module.exports = {
   createPages,
   onCreateNode,
+  onPreBuild,
 };

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -19,7 +19,8 @@ export const Footer: React.FC = () => {
             </ul>
           </nav>
         )}
-        <span>© 2023 All rights reserved zk Foundation</span>
+        <span>© 2024 All rights reserved zk Foundation</span>
+        <span style={{fontSize: "0.85em"}}>Build {process.env.GATSBY_GIT_SHA}↦{process.env.GATSBY_BUILD_DATE}</span>
       </div>
     </footer>
   );

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -55,6 +55,8 @@ export const Head = ({ pageContext }: PageNode) => {
       <meta name="twitter:card" content="summary_large_image" />
       <meta name="twitter:site" content={config.twitterName} />
       <meta name="og:site_name" content={config.title} />
+      <meta name="publish-date" content={process.env.GATSBY_BUILD_DATE} />
+      <meta name="version" content={process.env.GATSBY_GIT_SHA} />
     </>
   );
 };

--- a/src/gatsby/onPreBuild.ts
+++ b/src/gatsby/onPreBuild.ts
@@ -1,0 +1,8 @@
+import { execSync } from 'child_process';
+
+const onPreBuild = async () => {
+  process.env.GATSBY_BUILD_DATE = new Date().toISOString();
+  process.env.GATSBY_GIT_SHA = execSync('git rev-parse HEAD').toString().trim().substring(0,8);
+};
+
+export default onPreBuild;


### PR DESCRIPTION
# Description

Currently, there is no clear indication of what version of the docs is deployed. This change adds an indication of git SHA and build time in the footer of every page.

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
